### PR TITLE
Add time left display with correct font sizing to used sales shop

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/umbraprior/FS25-Community-LUADOC/refs/heads/main/docs/script/GUI/TextElement.md\")"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.1.0:
+- Display "Time left" with reduced font size on used sale items in the shop
+- Fix text size not applying by setting defaultTextSize on cloned UI element
+
 ## v0.0.0.1:
 - WIP
 - Super basic implementation of displaying the time left for each item in the used sales shop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Game Lua source is in `G:\Steam\steamapps\common\Farming Simulator 25\sdk\debugg
 Community-maintained API docs at: https://github.com/umbraprior/FS25-Community-LUADOC/tree/main/docs
 This is the primary reference for FS25 Lua commands and classes. Always consult these docs before falling back to the knowledge base PDFs or other sources.
 
-Raw file access pattern: `https://raw.githubusercontent.com/umbraprior/FS25-Community-LUADOC/main/docs/{path}`
+Raw file access pattern: `https://raw.githubusercontent.com/umbraprior/FS25-Community-LUADOC/refs/heads/main/docs/{path}` (files are `.md` format, not `.lua`)
 
 ### `docs/engine/` — Engine-level APIs (32 folders)
 Low-level GIANTS engine bindings: Animation, Camera, Debug, Entity, Fillplanes, Foliage, General, I3D, Input, Lighting, Math, NavMesh, Network, Node, NoteNode, Overlays, Particle System, Physics, PointList2D, Precipitation, Rendering, ShallowWaterSimulation, Shape, Sound, Spline, String, Terrain Detail, Terrain, Text Rendering, Tire Track, VoiceChat, XML.

--- a/FS25_UsedSalesTimeLeft/modDesc.xml
+++ b/FS25_UsedSalesTimeLeft/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>Retofel</author>
-    <version>0.0.0.1</version>
+    <version>0.0.1.0</version>
     <title>
         <en>Used Sales Time Left</en>
     </title>

--- a/FS25_UsedSalesTimeLeft/scripts/UsedSalesTimeLeft.lua
+++ b/FS25_UsedSalesTimeLeft/scripts/UsedSalesTimeLeft.lua
@@ -41,6 +41,10 @@ function UsedSalesTimeLeft:loadMap(filename)
                         timeLeftElement.name = "ustlTimeLeft"
                         timeLeftElement.textUpperCase = false
                         timeLeftElement.textAlignment = RenderText.ALIGN_LEFT
+                        -- Set defaultTextSize so setText() resets to our desired size, not the cloned original
+                        local desiredSize = valueCell.textSize * 0.6
+                        timeLeftElement.defaultTextSize = desiredSize
+                        timeLeftElement.textSize = desiredSize
                         -- Position at bottom-left, same vertical as priceTag
                         local pos = priceTagCell.position
                         timeLeftElement:setPosition(0, pos[2])


### PR DESCRIPTION
Set defaultTextSize on cloned TextElement so setText() doesn't reset the font size back to the original. Bump version to 0.0.1.0.