### PR TITLE
Extract debug utilities to lib/DebugUtils.lua and bump to v0.1.0.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,11 +4,12 @@
 A Farming Simulator 25 (PC) script mod that displays the remaining time (in hours) for each item listed in the in-game **used vehicle sales shop**. The game stores these items in `sales.xml` (per save), each with a `timeLeft` attribute representing hours before the item is removed from the shop.
 
 ## Current status
-Core functionality is implemented and working. The mod hooks into `ShopItemsFrame.populateCellForItemInSection` and displays hours remaining (e.g. "5h left") in a styled green box on each used sale item in the shop UI. The time-left box is cloned from the `priceTag` discount element (a `ThreePartBitmapElement`) so it inherits the game's green background, font, and state-dependent colors (green normally, black when selected/highlighted). The box is positioned at the bottom-left of each cell and auto-sizes its width to fit the text content. All mod logic is wrapped in `pcall` for error protection. Debug logging is available via `IS_DEBUG` flag (currently enabled for development).
+Core functionality is implemented and working. The mod hooks into `ShopItemsFrame.populateCellForItemInSection` and displays hours remaining (e.g. "5h left") in a styled green box on each used sale item in the shop UI. The time-left box is cloned from the `priceTag` discount element (a `ThreePartBitmapElement`) so it inherits the game's green background, font, and state-dependent colors (green normally, black when selected/highlighted). The box is positioned at the bottom-left of each cell and auto-sizes its width to fit the text content. All mod logic is wrapped in `pcall` for error protection. Debug logging utilities live in `lib/DebugUtils.lua` and are controlled via the `DebugUtils.IS_DEBUG` flag.
 
 ## Project structure
 - `FS25_UsedSalesTimeLeft/` — the actual mod folder (this gets zipped for distribution)
   - `modDesc.xml` — mod descriptor (descVersion must match current FS25 version, currently `106`)
+  - `lib/DebugUtils.lua` — debug/logging utilities
   - `scripts/UsedSalesTimeLeft.lua` — main mod script
   - `icon_UsedSalesTimeLeft.dds` — mod icon (512x512 DDS, BC1 format, no mipmaps)
 - `examples/` — reference mods for learning patterns
@@ -149,6 +150,7 @@ Before creating a release ready version of the mod, these must be completed:
  - Xtreme Used Sales Unlocker
  - Sales Plus
  - TidyShop: ModTitles
+- A Save with a previous version of the mod, replace with the new version, make sure it works proeprly.
 
 ## Language
 Lua (FS25 scripting language)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.0.1
+- Updated modDesc.xml
+### Internal changes:
+- Some tidying up of the code.
+- Moved the debugging logic to its own helper library.
+- Changed ORANGE to YELLOW for the color name, as it suits better to the actual color.
+- Updated CLAUDE.md
+
 ## v0.1.0.0:
 - Added color coded time left boxes that change based on the time remaining for each sale item. See modDesc.xml for the thresholds.
 - Updated mod description in modDesc.xml with color threshold details

--- a/FS25_UsedSalesTimeLeft/lib/DebugUtils.lua
+++ b/FS25_UsedSalesTimeLeft/lib/DebugUtils.lua
@@ -1,0 +1,86 @@
+--
+-- DebugUtils
+-- Debug and logging utilities for UsedSalesTimeLeft.
+--
+-- Author: Retofel
+--
+
+DebugUtils = {}
+DebugUtils.IS_DEBUG = false -- Set to true to enable debug logging
+
+--- Prints a debug message to the game log when IS_DEBUG is enabled.
+-- @param string message The message to print
+function DebugUtils.debugLog(message)
+    if DebugUtils.IS_DEBUG then
+        print("USTL: " .. message)
+    end
+end
+
+--- Prints an error message to the game log (always, regardless of IS_DEBUG).
+-- @param string message The error message to print
+function DebugUtils.errorLog(message)
+    print("USTL ERROR: " .. message)
+end
+
+--- Logs details of a used sale item for debugging.
+-- @param integer section The shop list section index
+-- @param integer index The item index within the section
+-- @param table sale The saleItem table containing item data
+function DebugUtils.debugLogSaleItem(section, index, sale)
+    DebugUtils.debugLog(string.format(
+        "ITEM - section=%d index=%d id=%s xmlFilename=%s timeLeft=%s price=%d age=%s wear=%.2f damage=%.2f",
+        section, index,
+        tostring(sale.id),
+        tostring(sale.xmlFilename),
+        tostring(sale.timeLeft),
+        math.floor(sale.price or 0),
+        tostring(sale.age),
+        sale.wear or 0,
+        sale.damage or 0
+    ))
+end
+
+--- Logs all attributes of a shop list cell for debugging (names, child counts, overlay colors).
+-- Only runs when IS_DEBUG is enabled. Used to discover cell attribute names.
+-- @param table cell The ListItemElement cell to inspect
+function DebugUtils.debugLogCellAttributes(cell)
+    if not DebugUtils.IS_DEBUG then
+        return
+    end
+    for name, element in pairs(cell.attributes) do
+        local colorInfo = ""
+        if element.overlay ~= nil and element.overlay.color ~= nil then
+            local c = element.overlay.color
+            colorInfo = string.format(" overlayColor=%.2f,%.2f,%.2f,%.2f", c[1], c[2], c[3], c[4])
+        end
+        DebugUtils.debugLog(string.format(
+            "Cell attr: name=%s children=%d%s",
+            tostring(name), #element.elements, colorInfo
+        ))
+    end
+end
+
+--- Logs all color state values of a cloned element for debugging.
+-- @param table box The ThreePartBitmapElement to inspect
+function DebugUtils.debugLogColors(box)
+    if not DebugUtils.IS_DEBUG then
+        return
+    end
+    local function fmtColor(c)
+        if c == nil then return "nil" end
+        return string.format("%.2f,%.2f,%.2f,%.2f", c[1], c[2], c[3], c[4])
+    end
+    if box.overlay then
+        DebugUtils.debugLog("Box overlay.color: " .. fmtColor(box.overlay.color))
+        DebugUtils.debugLog("Box overlay.colorFocused: " .. fmtColor(box.overlay.colorFocused))
+        DebugUtils.debugLog("Box overlay.colorSelected: " .. fmtColor(box.overlay.colorSelected))
+        DebugUtils.debugLog("Box overlay.colorHighlighted: " .. fmtColor(box.overlay.colorHighlighted))
+    end
+    local textChild = box.elements[1]
+    if textChild then
+        DebugUtils.debugLog("Text textColor: " .. fmtColor(textChild.textColor))
+        DebugUtils.debugLog("Text textSelectedColor: " .. fmtColor(textChild.textSelectedColor))
+        DebugUtils.debugLog("Text textFocusedColor: " .. fmtColor(textChild.textFocusedColor))
+        DebugUtils.debugLog("Text textHighlightedColor: " .. fmtColor(textChild.textHighlightedColor))
+    end
+end

--- a/FS25_UsedSalesTimeLeft/modDesc.xml
+++ b/FS25_UsedSalesTimeLeft/modDesc.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>Retofel</author>
-    <version>0.1.0.0</version>
+    <version>0.1.0.1</version>
     <title>
         <en>Used Sales Time Left</en>
     </title>
     <description>
-        <en><![CDATA[In the used vehicle sale shop you would find great deals on used equipment. But how long do you have until those deals become unavailable?
+        <en><![CDATA[In the used vehicle sale shop you will find great deals on used equipment. But how long do you have until those deals become unavailable?
 This mod shows you for each deal, how long you have until it goes away (in in-game hours), in a simple, clear, color coded way.
 
 The color changes based on the hours left.
@@ -19,6 +19,7 @@ For bug reports and feature requests, see: https://github.com/Retofel/FS25_UsedS
     <iconFilename>icon_UsedSalesTimeLeft.dds</iconFilename>
     <multiplayer supported="false"/>
     <extraSourceFiles>
+        <sourceFile filename="lib/DebugUtils.lua"/>
         <sourceFile filename="scripts/UsedSalesTimeLeft.lua"/>
     </extraSourceFiles>
 </modDesc>

--- a/FS25_UsedSalesTimeLeft/scripts/UsedSalesTimeLeft.lua
+++ b/FS25_UsedSalesTimeLeft/scripts/UsedSalesTimeLeft.lua
@@ -7,11 +7,10 @@
 
 UsedSalesTimeLeft = {}
 UsedSalesTimeLeft.TEXT_FORMAT = "%dh left" -- Format string for the time left label (%d = hours remaining)
-UsedSalesTimeLeft.IS_DEBUG = false -- Set to true to enable debug logging
 
--- Box background colors (RGBA, 0-1 range) - values to be verified via debug log
+-- Box background colors (RGBA, 0-1 range)
 UsedSalesTimeLeft.COLOR_GREEN = {0.22, 0.41, 0.00, 1.00}
-UsedSalesTimeLeft.COLOR_ORANGE = {0.70, 0.40, 0.00, 1.00}
+UsedSalesTimeLeft.COLOR_YELLOW = {0.70, 0.40, 0.00, 1.00}
 UsedSalesTimeLeft.COLOR_RED = {0.85, 0.08, 0.08, 1.00}
 
 -- Time thresholds (hours) for color selection
@@ -27,61 +26,9 @@ function UsedSalesTimeLeft.getColorForTimeLeft(timeLeft)
     if hours >= UsedSalesTimeLeft.MIN_THRESHOLD_GREEN then
         return UsedSalesTimeLeft.COLOR_GREEN
     elseif hours >= UsedSalesTimeLeft.MIN_THRESHOLD_ORANGE then
-        return UsedSalesTimeLeft.COLOR_ORANGE
+        return UsedSalesTimeLeft.COLOR_YELLOW
     else
         return UsedSalesTimeLeft.COLOR_RED
-    end
-end
-
---- Prints a debug message to the game log when IS_DEBUG is enabled.
--- @param string message The message to print
-function UsedSalesTimeLeft.debugLog(message)
-    if UsedSalesTimeLeft.IS_DEBUG then
-        print("USTL: " .. message)
-    end
-end
-
---- Prints an error message to the game log (always, regardless of IS_DEBUG).
--- @param string message The error message to print
-function UsedSalesTimeLeft.errorLog(message)
-    print("USTL ERROR: " .. message)
-end
-
---- Logs details of a used sale item for debugging.
--- @param integer section The shop list section index
--- @param integer index The item index within the section
--- @param table sale The saleItem table containing item data
-function UsedSalesTimeLeft.debugLogSaleItem(section, index, sale)
-    UsedSalesTimeLeft.debugLog(string.format(
-        "USTL ITEM - section=%d index=%d id=%s xmlFilename=%s timeLeft=%s price=%d age=%s wear=%.2f damage=%.2f",
-        section, index,
-        tostring(sale.id),
-        tostring(sale.xmlFilename),
-        tostring(sale.timeLeft),
-        math.floor(sale.price or 0),
-        tostring(sale.age),
-        sale.wear or 0,
-        sale.damage or 0
-    ))
-end
-
---- Logs all attributes of a shop list cell for debugging (names, child counts, overlay colors).
--- Only runs when IS_DEBUG is enabled. Used to discover cell attribute names.
--- @param table cell The ListItemElement cell to inspect
-function UsedSalesTimeLeft.debugLogCellAttributes(cell)
-    if not UsedSalesTimeLeft.IS_DEBUG then
-        return
-    end
-    for name, element in pairs(cell.attributes) do
-        local colorInfo = ""
-        if element.overlay ~= nil and element.overlay.color ~= nil then
-            local c = element.overlay.color
-            colorInfo = string.format(" overlayColor=%.2f,%.2f,%.2f,%.2f", c[1], c[2], c[3], c[4])
-        end
-        UsedSalesTimeLeft.debugLog(string.format(
-            "Cell attr: name=%s children=%d%s",
-            tostring(name), #element.elements, colorInfo
-        ))
     end
 end
 
@@ -110,31 +57,6 @@ function UsedSalesTimeLeft.applyBoxColor(timeLeftBox, color)
     end
 end
 
---- Logs all color state values of a cloned element for debugging.
--- @param table box The ThreePartBitmapElement to inspect
-function UsedSalesTimeLeft.debugLogColors(box)
-    if not UsedSalesTimeLeft.IS_DEBUG then
-        return
-    end
-    local function fmtColor(c)
-        if c == nil then return "nil" end
-        return string.format("%.2f,%.2f,%.2f,%.2f", c[1], c[2], c[3], c[4])
-    end
-    if box.overlay then
-        UsedSalesTimeLeft.debugLog("Box overlay.color: " .. fmtColor(box.overlay.color))
-        UsedSalesTimeLeft.debugLog("Box overlay.colorFocused: " .. fmtColor(box.overlay.colorFocused))
-        UsedSalesTimeLeft.debugLog("Box overlay.colorSelected: " .. fmtColor(box.overlay.colorSelected))
-        UsedSalesTimeLeft.debugLog("Box overlay.colorHighlighted: " .. fmtColor(box.overlay.colorHighlighted))
-    end
-    local textChild = box.elements[1]
-    if textChild then
-        UsedSalesTimeLeft.debugLog("Text textColor: " .. fmtColor(textChild.textColor))
-        UsedSalesTimeLeft.debugLog("Text textSelectedColor: " .. fmtColor(textChild.textSelectedColor))
-        UsedSalesTimeLeft.debugLog("Text textFocusedColor: " .. fmtColor(textChild.textFocusedColor))
-        UsedSalesTimeLeft.debugLog("Text textHighlightedColor: " .. fmtColor(textChild.textHighlightedColor))
-    end
-end
-
 --- Clones the discount box element and configures it as a time-left display.
 -- Creates a ThreePartBitmapElement clone with the discount box's styled background,
 -- font, and state-dependent colors. Installs a draw() override to force left-side
@@ -146,7 +68,7 @@ function UsedSalesTimeLeft.createTimeLeftBox(discountElement, cell)
     local timeLeftBox = discountElement:clone()
     timeLeftBox.name = "ustlTimeLeft"
 
-    UsedSalesTimeLeft.debugLogColors(timeLeftBox)
+    DebugUtils.debugLogColors(timeLeftBox)
 
     -- Fix child text: disable percentage format, ensure center alignment
     local initChild = timeLeftBox.elements[1]
@@ -196,7 +118,7 @@ end
 -- @param integer section The shop list section index (for debug logging)
 -- @param integer index The item index within the section (for debug logging)
 function UsedSalesTimeLeft.updateTimeLeftDisplay(cell, sale, section, index)
-    UsedSalesTimeLeft.debugLogSaleItem(section, index, sale)
+    DebugUtils.debugLogSaleItem(section, index, sale)
 
     local discountElement = cell:getAttribute("priceTag")
     if discountElement == nil then
@@ -218,7 +140,7 @@ function UsedSalesTimeLeft.updateTimeLeftDisplay(cell, sale, section, index)
     if textChild ~= nil then
         textChild:setText(timeText)
     end
-    UsedSalesTimeLeft.debugLog(string.format(
+    DebugUtils.debugLog(string.format(
         "timeLeft absPos=%.4f,%.4f absSize=%.4f,%.4f cellAbsPos=%.4f",
         cell.ustlTimeLeft.absPosition[1], cell.ustlTimeLeft.absPosition[2],
         cell.ustlTimeLeft.absSize[1], cell.ustlTimeLeft.absSize[2],
@@ -230,10 +152,10 @@ end
 -- Hooks into ShopItemsFrame.populateCellForItemInSection to display
 -- time remaining on used sale items in the shop UI.
 function UsedSalesTimeLeft:loadMap(filename)
-    UsedSalesTimeLeft.debugLog("loadMap called")
+    DebugUtils.debugLog("loadMap called")
 
     if ShopItemsFrame == nil then
-        UsedSalesTimeLeft.debugLog("ShopItemsFrame is nil!")
+        DebugUtils.debugLog("ShopItemsFrame is nil!")
         return
     end
 
@@ -243,8 +165,9 @@ function UsedSalesTimeLeft:loadMap(filename)
             local returnValue = superFunc(self, list, section, index, cell, ...)
 
             local ok, err = pcall(function()
+                -- displayItems[index] maps 1:1 with list rows; saleItem is non-nil only for used-sale entries
                 local displayItem = self.displayItems[index]
-                UsedSalesTimeLeft.debugLogCellAttributes(cell)
+                DebugUtils.debugLogCellAttributes(cell)
 
                 if displayItem ~= nil and displayItem.saleItem ~= nil then
                     UsedSalesTimeLeft.updateTimeLeftDisplay(cell, displayItem.saleItem, section, index)
@@ -257,13 +180,13 @@ function UsedSalesTimeLeft:loadMap(filename)
             end)
 
             if not ok then
-                UsedSalesTimeLeft.errorLog(tostring(err))
+                DebugUtils.errorLog(tostring(err))
             end
 
             return returnValue
         end
     )
-    UsedSalesTimeLeft.debugLog("Hooked into ShopItemsFrame.populateCellForItemInSection")
+    DebugUtils.debugLog("Hooked into ShopItemsFrame.populateCellForItemInSection")
 end
 
 --- FS25 mod lifecycle callback - called when the map is unloaded. Required by addModEventListener.


### PR DESCRIPTION
* Move all debug/logging functions from UsedSalesTimeLeft.lua into a dedicated DebugUtils library for cleaner separation of concerns. 
* Rename COLOR_ORANGE to COLOR_YELLOW to better reflect the actual color. Minor modDesc description wording fix.