### PR TITLE
Remove modDesc version line from v1.0.1.0 changelog

### DIFF
--- a/FS25_UsedSalesTimeLeft/modDesc.xml
+++ b/FS25_UsedSalesTimeLeft/modDesc.xml
@@ -19,8 +19,7 @@ For bug reports and feature requests, see: https://github.com/Retofel/FS25_UsedS
 Changelog:
 Version 1.0.1.0:
 * Time left is now capped at 100 hours, anything above shows as "100h+".
-* Fixed the time left not showing for multiplayer clients on dedicated servers. Thanks ScottyMcTotty, Hauklotz, FarmerMike for reporting, suggesting a fix and testing.
-* Updated modDesc version.]]></en>
+* Fixed the time left not showing for multiplayer clients on dedicated servers. Thanks ScottyMcTotty, Hauklotz, FarmerMike for reporting, suggesting a fix and testing.]]></en>
         <de><![CDATA[Im Gebrauchtwagen-Shop findest du tolle Angebote für gebrauchte Fahrzeuge. Aber wie lange hast du noch Zeit, bevor diese Angebote verfallen?
 Dieser Mod zeigt dir für jedes Angebot auf einfache, übersichtliche und farbcodierte Weise an, wie lange du noch Zeit hast, bis es verfällt (in Spielstunden).
 
@@ -35,7 +34,6 @@ Für Fehlerberichte und Feature-Anfragen siehe: https://github.com/Retofel/FS25_
 Version 1.0.1.0:
 * Die verbleibende Zeit ist nun auf 100 Stunden begrenzt; alles darüber hinaus wird als "100h+" angezeigt.
 * Es wurde behoben, dass die verbleibende Zeit für Multiplayer-Clients auf dedizierten Servern nicht angezeigt wurde. Vielen Dank an ScottyMcTotty, Hauklotz und FarmerMike für den Hinweis, den Lösungsvorschlag und das Testen.
-* Die ModDesc-Version wurde aktualisiert.
 
 (Automatisch übersetzt)]]></de>
         <fr><![CDATA[Dans la boutique de vente de véhicules d'occasion, vous trouverez des offres exceptionnelles sur du matériel d'occasion. Mais combien de temps vous reste-t-il avant que ces offres n'expirent ?
@@ -52,7 +50,6 @@ Journal des modifications:
 Version 1.0.1.0:
 * Le temps restant est désormais plafonné à 100 heures ; tout dépassement s'affiche sous la forme "100h+".
 * Correction d'un problème qui empêchait l'affichage du temps restant pour les clients multijoueurs sur les serveurs dédiés. Merci à ScottyMcTotty, Hauklotz et FarmerMike pour avoir signalé le problème, proposé une solution et effectué les tests.
-* Mise à jour de la version de modDesc.
 
 (Traduit automatiquement)]]></fr>
     </description>


### PR DESCRIPTION
Dropped the "Updated modDesc version" bullet from the EN, DE and FR changelogs — it is an internal detail with no player-facing meaning.